### PR TITLE
/wsでcliのsearchを呼び出すように変更

### DIFF
--- a/fastapi/Dockerfile
+++ b/fastapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -39,11 +39,14 @@ async def websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)
     await websocket.accept()
     while True:
         data = await websocket.receive_text()
-        responses = search(path=data_path, query=data, size=3, only_interviewer=True)
-        response = random.choice(responses)
-        # responseの頭に含まれる「面接官: 」を取り除く
-        response  = str(response).replace("面接官: ", "")
-        await websocket.send_text(f"{response}")
+        # 候補者の発言に似たテキストを検索
+        similar_candidate_replies = search(path=data_path, query=data, size=3, only_candidate=True)
+        similar_students_reply = random.choice(similar_candidate_replies)
+        # そのテキストに対応する返答を取得
+        interviewer_response_content = random.choice(similar_students_reply.children).comment
+        # interviewer_response_contentの頭に含まれる「面接官: 」を取り除く
+        interviewer_response_content  = interviewer_response_content.replace("面接官: ", "")
+        await websocket.send_text(f"{interviewer_response_content}")
 
 
 @app.post("/responses/", response_model=HumanResponse)

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -44,8 +44,6 @@ async def websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)
         similar_students_reply = random.choice(similar_candidate_replies)
         # そのテキストに対応する返答を取得
         interviewer_response_content = random.choice(similar_students_reply.children).comment
-        # interviewer_response_contentの頭に含まれる「面接官: 」を取り除く
-        interviewer_response_content  = interviewer_response_content.replace("面接官: ", "")
         await websocket.send_text(f"{interviewer_response_content}")
 
 

--- a/fastapi/requirements.txt
+++ b/fastapi/requirements.txt
@@ -3,3 +3,9 @@ uvicorn[standard]
 python-socketio
 sqlalchemy
 psycopg2-binary
+fire
+openai
+loguru
+python-dotenv
+tqdm
+numpy

--- a/fastapi/src/cli.py
+++ b/fastapi/src/cli.py
@@ -1,6 +1,6 @@
 from fire import Fire
 from datetime import datetime
-from data import generate_reply_tree, Reply, Chara
+from .data import generate_reply_tree, Reply, Chara
 from pathlib import Path
 from loguru import logger
 
@@ -31,6 +31,9 @@ def search(path: str, query: str, size: int=5, only_candidate: bool=False, only_
     replies = search(query, size=size, allows=allows)
     for reply in replies:
         logger.success(str(reply))
+
+    return replies
+
 
 if __name__ == "__main__":
     Fire({


### PR DESCRIPTION
# 主な変更点
- fastapiのmain.pyの中でcli.searchを呼び出し、得られたReplayの中からランダムで一つ出力するように
  - queryにフロントエンドから受け取った文字列を与えていて、それ以外のパラメータは現状では固定されている

# その他の変更
- dockerfileのpythonバージョンを3.12にあげた(match文が3.9では対応していなかったため)
- poetryとdockerをうまく組み合わせられなかったので、現状はrequirements.txtに必要パッケージを書き出しておく形になってます🙏